### PR TITLE
feat: add bilingual (English/Hindi) support

### DIFF
--- a/backend/voice-assistant/chat.js
+++ b/backend/voice-assistant/chat.js
@@ -1,15 +1,39 @@
-import OpenAI from 'openai';
+// chat.js – bilingual (Hindi / English)
+// -----------------------------------------------------------------------------
 import dotenv from 'dotenv';
+import OpenAI from 'openai';
+
 dotenv.config();
+
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+/**
+ * Very lightweight language detector: checks for any Devanagari code points.
+ * Returns 'hi' for Hindi, 'en' otherwise.
+ */
+function detectLang(str = '') {
+  return /[\u0900-\u097F]/.test(str) ? 'hi' : 'en';
+}
+
+/**
+ * Send user text to OpenAI Chat Completion and return assistant answer
+ * in the same language (Hindi or English).
+ */
 export async function chat(userText = '') {
-  const { choices } = await openai.chat.completions.create({
+  const lang = detectLang(userText);
+
+  const systemPrompt =
+    lang === 'hi'
+      ? 'आप एक संक्षिप्त, सहायक वॉयस असिस्टेंट हैं। अपने सभी उत्तर **हिंदी** में दीजिए। यदि उपयोगकर्ता भाषा बदलता है तो उसका अनुसरण कीजिये।'
+      : 'You are a concise, helpful voice assistant. If the user switches language, follow the user.';
+
+  const completion = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
     messages: [
-      { role: 'system', content: 'You are a concise, helpful voice assistant.' },
+      { role: 'system', content: systemPrompt },
       { role: 'user',   content: userText }
     ]
   });
-  return choices[0].message.content.trim();
+
+  return completion.choices[0].message.content.trim();
 }

--- a/backend/voice-assistant/stt_server.py
+++ b/backend/voice-assistant/stt_server.py
@@ -1,51 +1,112 @@
+#!/usr/bin/env python3
+"""
+stt_server.py – WebSocket wrapper around Vosk for English & Hindi
+
+* Defaults to English model at ./models/en-in
+* Optional Hindi model at ./models/hi-in
+* Client MAY send a JSON control packet as the very first message:
+      {"lang": "hi"}          # or "en"
+  If so, that model will be used for the remainder of the connection.
+* Subsequent messages must be raw PCM 16-bit little-endian mono at 16 kHz.
+* Server streams back JSON packets:
+      {"text": "<partial>", "final": false}
+      {"text": "<final>",  "final": true}
+"""
 
 import asyncio
 import json
 import os
 import sys
+from typing import Dict, Optional
+
 from vosk import Model, KaldiRecognizer
 import websockets
 from websockets.exceptions import ConnectionClosedOK
 
-MODEL_PATH = os.getenv("VOSK_MODEL_PATH", "./models/en-in")
-SAMPLE_RATE = 16000
-WS_PORT = 2700
+DEFAULT_MODEL_PATH = os.getenv("VOSK_MODEL_PATH", "./models/en-in")
+EXTRA_MODELS: Dict[str, str] = {
+    "hi": "./models/hi-in",
+    "en": DEFAULT_MODEL_PATH,   # alias for clarity
+}
 
-if not os.path.exists(MODEL_PATH):
-    print(f"Model path not found: {MODEL_PATH}", file=sys.stderr)
+SAMPLE_RATE = 16000
+WS_PORT = int(os.getenv("STT_WS_PORT", "2700"))
+
+# Pre-load default model; others will lazy-load on demand
+if not os.path.exists(DEFAULT_MODEL_PATH):
+    print(f"❌ Model path not found: {DEFAULT_MODEL_PATH}", file=sys.stderr)
     sys.exit(1)
 
-model = Model(MODEL_PATH)
+_cached_models: Dict[str, Model] = {"en": Model(DEFAULT_MODEL_PATH)}
 
-async def handler(ws):
-    rec = KaldiRecognizer(model, SAMPLE_RATE)
+def get_model(lang: str) -> Model:
+    """Return (and cache) Vosk Model for given language code."""
+    if lang not in _cached_models:
+        path = EXTRA_MODELS.get(lang)
+        if not path or not os.path.exists(path):
+            print(f"⚠️  Falling back to English – model not found for {lang}", file=sys.stderr)
+            return _cached_models["en"]
+        _cached_models[lang] = Model(path)
+    return _cached_models[lang]
+
+async def send_result(ws, text: str, final: bool):
+    """Utility to send recognizer result JSON."""
+    await ws.send(json.dumps({"text": text, "final": final}))
+
+async def handle_connection(ws):
+    # ---- Optional language control packet ----------------------------------
     try:
-        async for msg in ws:
-            if rec.AcceptWaveform(msg):
-                data = json.loads(rec.Result())
-                try:
-                    await ws.send(json.dumps({
-                        "text": data.get("text", ""),
-                        "final": True
-                    }))
-                except ConnectionClosedOK:
-                    break
-            else:
-                data = json.loads(rec.PartialResult())
-                try:
-                    await ws.send(json.dumps({
-                        "text": data.get("partial", ""),
-                        "final": False
-                    }))
-                except ConnectionClosedOK:
-                    break
+        first_msg = await ws.recv()
     except ConnectionClosedOK:
-        
+        return
+
+    chosen_lang: str = "en"
+    recogniser: Optional[KaldiRecognizer] = None
+
+    if isinstance(first_msg, (bytes, bytearray)):
+        # No control packet – treat as audio chunk and use default model
+        recogniser = KaldiRecognizer(get_model("en"), SAMPLE_RATE)
+        await process_audio_stream(ws, recogniser, first_msg)
+        return
+
+    # first message was text → try to parse JSON
+    try:
+        cfg = json.loads(first_msg)
+        if isinstance(cfg, dict) and cfg.get("lang") in EXTRA_MODELS:
+            chosen_lang = cfg["lang"]
+            recogniser = KaldiRecognizer(get_model(chosen_lang), SAMPLE_RATE)
+        else:
+            recogniser = KaldiRecognizer(get_model("en"), SAMPLE_RATE)
+    except json.JSONDecodeError:
+        recogniser = KaldiRecognizer(get_model("en"), SAMPLE_RATE)
+
+    # Now process remaining audio chunks
+    await process_audio_stream(ws, recogniser)
+
+async def process_audio_stream(ws, recogniser: KaldiRecognizer, first_chunk: bytes = None):
+    """Read raw PCM chunks from websocket, stream partial & final results."""
+    try:
+        if first_chunk is not None:
+            if recogniser.AcceptWaveform(first_chunk):
+                result = json.loads(recogniser.Result())
+                await send_result(ws, result.get("text", ""), True)
+            else:
+                partial = json.loads(recogniser.PartialResult())
+                await send_result(ws, partial.get("partial", ""), False)
+
+        async for msg in ws:
+            if recogniser.AcceptWaveform(msg):
+                result = json.loads(recogniser.Result())
+                await send_result(ws, result.get("text", ""), True)
+            else:
+                partial = json.loads(recogniser.PartialResult())
+                await send_result(ws, partial.get("partial", ""), False)
+    except ConnectionClosedOK:
         pass
 
 async def main():
-    async with websockets.serve(handler, "0.0.0.0", WS_PORT):
-        print(f"Python STT WS running on ws://localhost:{WS_PORT}")
+    async with websockets.serve(handle_connection, "0.0.0.0", WS_PORT, max_size=None):
+        print(f"🗣️  STT WS (multi-lingual) running on ws://localhost:{WS_PORT}")
         await asyncio.Future()  # run forever
 
 if __name__ == "__main__":

--- a/backend/voice-assistant/tts.js
+++ b/backend/voice-assistant/tts.js
@@ -1,13 +1,30 @@
+// tts.js – bilingual Text-to-Speech helper
+// -----------------------------------------------------------------------------
 import 'dotenv/config';
 import OpenAI from 'openai';
+
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function tts(text) {
+/** Detects Hindi by spotting Devanagari characters. */
+function detectLang(str = '') {
+  return /[\u0900-\u097F]/.test(str) ? 'hi' : 'en';
+}
+
+/**
+ * Generate speech (MP3 buffer) from text.
+ * OpenAI TTS supports multiple languages automatically; we still send a
+ * language hint for clarity.
+ */
+export async function tts(text = '') {
+  const langHint = detectLang(text);
+
   const speech = await openai.audio.speech.create({
     model: 'tts-1',
-    voice: 'alloy',
+    voice: 'alloy',           // multi-lingual voice works for hi & en
     input: text,
-    response_format: 'mp3'
+    response_format: 'mp3',   // same param name as before
+    language: langHint        // ignored by older SDKs but harmless
   });
+
   return Buffer.from(await speech.arrayBuffer());
 }


### PR DESCRIPTION
## Pull Request: Add Hindi Support to Chat, TTS, and STT Modules

*Summary*
This PR updates our voice-assisted backend to handle both English and Hindi seamlessly. It includes:

* *chat.js*

  * Language detection (Devanagari vs. Latin)
  * Dynamically sets system prompt in Hindi or English

* *tts.js*

  * Detects script of input text and passes a language hint to OpenAI TTS
  * Returns MP3 audio for both Hindi and English

* *stt\_server.py*

  * Supports two Vosk models (en-in, hi-in)
  * Allows client to select language via a JSON control packet ({ "lang": "hi" } or { "lang": "en" })
  * Streams back partial and final transcripts over WebSocket

* *Model installation instructions*

  * Adds steps to download and unzip the Hindi Vosk model

---

*How to Test*

1. Merge the branch and pull the latest code.
2. Download the Hindi model under ./models/hi-in (see instructions).
3. Restart the Node server and the Python STT server.
4. Verify /chat and /tts endpoints return responses in the correct language.
5. Verify STT WebSocket accepts { "lang": "hi" } and correctly transcribes Hindi audio.

Please review and merge!